### PR TITLE
Fix VectorSlice.all and ArraySlice.all

### DIFF
--- a/base/system/Basis/Implementation/array-slice.sml
+++ b/base/system/Basis/Implementation/array-slice.sml
@@ -261,9 +261,9 @@ structure ArraySlice : ARRAY_SLICE =
 
     fun all pred (SL(base, start, len)) = let
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
     fun collate cmp (SL(b1, s1, l1), SL(b2, s2, l2)) = let

--- a/base/system/Basis/Implementation/char-vector-slice.sml
+++ b/base/system/Basis/Implementation/char-vector-slice.sml
@@ -135,9 +135,9 @@ structure CharVectorSlice :> MONO_VECTOR_SLICE
     fun all pred vs = let
 	  val (base, start, len) = SS.base vs
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
   (* added for Basis Library proposal 2018-002 *)

--- a/base/system/Basis/Implementation/real64-array-slice.sml
+++ b/base/system/Basis/Implementation/real64-array-slice.sml
@@ -264,9 +264,9 @@ structure Real64ArraySlice : MONO_ARRAY_SLICE
 
     fun all pred (SL(base, start, len)) = let
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
     fun collate cmp (SL(b1, s1, l1), SL(b2, s2, l2)) = let

--- a/base/system/Basis/Implementation/vector-slice.sml
+++ b/base/system/Basis/Implementation/vector-slice.sml
@@ -168,9 +168,9 @@ structure VectorSlice :> VECTOR_SLICE =
 
     fun all pred (SL(base, start, len)) = let
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
     fun concat sll =

--- a/base/system/Basis/Implementation/word8-array-slice.sml
+++ b/base/system/Basis/Implementation/word8-array-slice.sml
@@ -259,9 +259,9 @@ structure Word8ArraySlice :> MONO_ARRAY_SLICE
 
     fun all pred (SL(base, start, len)) = let
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
     fun collate cmp (SL(b1, s1, l1), SL(b2, s2, l2)) = let

--- a/base/system/Basis/Implementation/word8-vector-slice.sml
+++ b/base/system/Basis/Implementation/word8-vector-slice.sml
@@ -202,9 +202,9 @@ structure Word8VectorSlice :> MONO_VECTOR_SLICE
 
     fun all pred (SL(base, start, len)) = let
 	  val stop = start ++ len
-	  fun ex i = (i < stop) andalso (pred (usub (base, i)) orelse ex (i ++ 1))
+	  fun al i = (i >= stop) orelse (pred (usub (base, i)) andalso al (i ++ 1))
 	  in
-	    ex start
+	    al start
 	  end
 
     fun concat sll = let


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These functions had the same implementation as the exists functions. CharArraySlice.all was correct; the other implementations are updated to match.

This should be applied to the the development version as well.
## Related Issue
n/a
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Bug fix.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I built SML/NJ and confirmed that the function works as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

