### PR TITLE
config: restore PPC for 10.4 and 10.6

### DIFF
--- a/config/_arch-n-opsys
+++ b/config/_arch-n-opsys
@@ -66,7 +66,9 @@ case `uname -s` in
       powerpc)
 	ARCH=$(pick_arch ppc ppc64)
 	case `uname -r` in
+	  8*) OPSYS=darwin;  HEAP_OPSYS=darwin ;; # MacOS X 10.4 Tiger
 	  9*) OPSYS=darwin;  HEAP_OPSYS=darwin ;; # MacOS X 10.5 Leopard
+	  10*) OPSYS=darwin;  HEAP_OPSYS=darwin ;; # MacOS X 10.6 Snow Leopard
 	  *) exit 1;;
 	esac;;
       i386)


### PR DESCRIPTION
Configure is missing settings for 10.4 and 10.6 for PowerPC, which causes the build to fail. These systems are still used, and have all developer tools needed to build `smlnj`.

I have confirmed it to build on 10.6 PPC (10A190) and 10.6.8 Rosetta. (Rosetta needs minor manual patching in order to convince the build system to ignore uname info and build for ppc32.)