### PR TITLE
Update makefile

### DIFF
--- a/base/runtime/c-libs/smlnj-date/makefile
+++ b/base/runtime/c-libs/smlnj-date/makefile
@@ -26,6 +26,7 @@ OBJS =		smlnj-date-lib.o \
 		strftime.o \
 		unix-date.o
 
+$(OBJS) : $(VERSION)
 $(LIBRARY)	: $(VERSION) $(OBJS)
 	rm -rf $(LIBRARY)
 	$(AR) $(ARFLAGS) $(LIBRARY) $(OBJS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sequence VERSION and OBJS
## Description
<!--- Describe your changes in detail -->

VERSION target make a clean, so it should be run before the compilation of objects
The new make shuffle can change the order of the right side of the rules, and 
also a parallel make can run both VERSION and OBJS in parallel.

The change proposed is not the best way to achieve that, as it does not check if the rule is already satisfied.