### PR TITLE
Dn2007hw patch 2 with mutecompiler

### DIFF
--- a/base/cm/main/cm-boot.sml
+++ b/base/cm/main/cm-boot.sml
@@ -690,17 +690,53 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 	  end
       end
   in
-    fun init (bootdir, de, er, useStream, useFile, errorwrap, icm) = let
+    fun init (bootdir, de, er, useStream, useScriptFile, useFile, errorwrap, icm) = let
 	fun procCmdLine () = let
 	    val autoload' = errorwrap (ignore o autoload mkStdSrcPath)
 	    val make' = errorwrap (ignore o makeStd)
-            fun processFile (file, mk, ext) = (case ext
+            fun processFile (file, mk, ext) = (
+				case ext
 		  of ("sml" | "sig" | "fun") => useFile file
 		   | "cm" => mk file
 		   | _ => Say.say [
 			"!* unable to process '", file, "' (unknown extension '", ext, "')\n"
 		      ]
 		  (* end case *))
+
+		  (* DAYA change starts here *)
+			fun eatuntilnewline (instream : TextIO.instream): bool = let
+    			val c = TextIO.input1 instream
+  				in
+    				case TextIO.lookahead instream of
+          				SOME #"\n" => true
+        				| SOME c => eatuntilnewline instream
+        				| NONE => false
+  				end
+
+			fun checkSharpbang (instream : TextIO.instream): bool = let
+	    		val c = TextIO.input1 instream
+  				in
+   					case c of
+      					SOME #"#" => (
+        					case TextIO.lookahead instream of
+          						SOME #"!" => eatuntilnewline instream
+        						| SOME c => false
+        						| NONE => false
+        						)
+    					| SOME c => false
+    					| NONE => false
+  				end
+
+			fun processFileScript (fname) = let
+				val stream = TextIO.openIn fname
+  				val isscript = checkSharpbang stream
+				in
+				  	if (isscript) = false  
+  					then	( Say.say [ "!* Script file doesn't start with #!. \n" ] ) 
+					else	( useScriptFile (fname, stream) )
+				end
+			(* DAYA change ends here *)
+
 	    fun inc n = n + 1
 	    fun show_controls (getarg, getval, padval) level = let
 		fun walk indent (ControlRegistry.RTree rt) = let
@@ -778,6 +814,7 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 		     \    <file>.cm        (CM.make or CM.autoload)\n\
 		     \    -m               (switch to CM.make)\n\
 		     \    -a               (switch to CM.autoload; default)\n\
+			 \    --script         (execute scripts)\n\
 		     \    <file>.sig       (use)\n\
 		     \    <file>.sml       (use)\n\
 		     \    <file>.fun       (use)\n\
@@ -878,6 +915,7 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 	      | args ("-S" :: _ :: _, mk) = (showcur NONE; nextarg mk)
 	      | args (["-E"], _) = (show_envvars NONE; quit ())
 	      | args ("-E" :: _ :: _, mk) = (show_envvars NONE; nextarg mk)
+		  | args ("--script" :: _, _) = (nextargscript ())  (* line added by Daya HWU *)
 	      | args ("@CMbuild" :: rest, _) = mlbuild rest
 	      | args (["@CMredump", heapfile], _) = redump_heap heapfile
 	      | args (f :: rest, mk) =
@@ -890,6 +928,13 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 		let val l = SMLofNJ.getArgs ()
 		in SMLofNJ.shiftArgs (); args (l, mk)
 		end
+
+		(* nextargscript added by Daya HWU *)
+		and nextargscript () =
+		let val l = SMLofNJ.getArgs ()
+		in SMLofNJ.shiftArgs (); processFileScript (hd l); quit ()
+		end
+
 	in
 	    case SMLofNJ.getArgs () of
 		["@CMslave"] => (#set StdConfig.verbose false; slave ())

--- a/base/cm/main/cm-boot.sml
+++ b/base/cm/main/cm-boot.sml
@@ -694,8 +694,7 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 	fun procCmdLine () = let
 	    val autoload' = errorwrap (ignore o autoload mkStdSrcPath)
 	    val make' = errorwrap (ignore o makeStd)
-            fun processFile (file, mk, ext) = (
-				case ext
+            fun processFile (file, mk, ext) = (case ext
 		  of ("sml" | "sig" | "fun") => useFile file
 		   | "cm" => mk file
 		   | _ => Say.say [
@@ -814,7 +813,7 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 		     \    <file>.cm        (CM.make or CM.autoload)\n\
 		     \    -m               (switch to CM.make)\n\
 		     \    -a               (switch to CM.autoload; default)\n\
-			 \    --script         (execute scripts)\n\
+		     \    --script         (execute scripts)\n\
 		     \    <file>.sig       (use)\n\
 		     \    <file>.sml       (use)\n\
 		     \    <file>.fun       (use)\n\
@@ -915,7 +914,7 @@ functor LinkCM (structure HostBackend : BACKEND) = struct
 	      | args ("-S" :: _ :: _, mk) = (showcur NONE; nextarg mk)
 	      | args (["-E"], _) = (show_envvars NONE; quit ())
 	      | args ("-E" :: _ :: _, mk) = (show_envvars NONE; nextarg mk)
-		  | args ("--script" :: _, _) = (nextargscript ())  (* line added by Daya HWU *)
+	      | args ("--script" :: _, _) = (nextargscript ())  (* line added by Daya HWU *)
 	      | args ("@CMbuild" :: rest, _) = mlbuild rest
 	      | args (["@CMredump", heapfile], _) = redump_heap heapfile
 	      | args (f :: rest, mk) =

--- a/base/compiler/INDEX
+++ b/base/compiler/INDEX
@@ -271,6 +271,10 @@ MODULEUTIL
   ElabData/modules/moduleutil.sig
 ModuleUtil
   ElabData/modules/moduleutil.sml
+MUTECOMPILER
+  TopLevel/interact/mutecompiler.sig
+Mutecompiler
+  TopLevel/interact/mutecompiler.sml
 PARSER_CONTROL
   Parse/main/parsercontrol.sml
 ParserControl

--- a/base/compiler/MAP
+++ b/base/compiler/MAP
@@ -518,7 +518,6 @@ Library/   (was MiscUtil)
       supporting unpickling
       defs: UNPICKLE_UTIL, UnpickleUtil :> UNPICKLE_UTIL
 
-
 3. Middle End
 -------------
 
@@ -623,6 +622,9 @@ TopLevel/
     interact.sig,sml
       creating top-level loops
       defs: INTERACT, Interact: EVALLOOP => INTERACT
+    mutecompiler.sig,sml
+      allow compiler silencing
+      defs: MUTECOMPILER, Mutecompiler
 
   print/
   Pretty printing for absyn declarations, values

--- a/base/compiler/MAP
+++ b/base/compiler/MAP
@@ -518,6 +518,7 @@ Library/   (was MiscUtil)
       supporting unpickling
       defs: UNPICKLE_UTIL, UnpickleUtil :> UNPICKLE_UTIL
 
+
 3. Middle End
 -------------
 

--- a/base/compiler/TopLevel/backend/backend-fn.sml
+++ b/base/compiler/TopLevel/backend/backend-fn.sml
@@ -92,4 +92,5 @@ functor BackendFn (
     structure Machine = M.Machine
     val architecture = M.architecture
     val abi_variant = M.abi_variant
+	structure Mutecompiler = Mutecompiler
 end

--- a/base/compiler/TopLevel/backend/backend-fn.sml
+++ b/base/compiler/TopLevel/backend/backend-fn.sml
@@ -92,5 +92,5 @@ functor BackendFn (
     structure Machine = M.Machine
     val architecture = M.architecture
     val abi_variant = M.abi_variant
-	structure Mutecompiler = Mutecompiler
+    structure Mutecompiler = Mutecompiler
 end

--- a/base/compiler/TopLevel/backend/backend.sig
+++ b/base/compiler/TopLevel/backend/backend.sig
@@ -6,6 +6,7 @@ signature BACKEND = sig
     structure Profile : PROFILE
     structure Compile : COMPILE
     structure Interact : INTERACT
+    structure Mutecompiler : MUTECOMPILER
     structure Machine : MACHINE
     val architecture: string
     val abi_variant: string option

--- a/base/compiler/TopLevel/interact/interact.sig
+++ b/base/compiler/TopLevel/interact/interact.sig
@@ -27,6 +27,7 @@ signature INTERACT =
     val useFile : string -> bool
 
     val useStream : TextIO.instream -> unit
+    val useScriptFile : string * TextIO.instream -> unit (* Addded by DAYA *)
     val evalStream : TextIO.instream * Environment.environment -> Environment.environment
 
     val withErrorHandling : bool -> (* true: treat all exns like usercode exns *)

--- a/base/compiler/TopLevel/interact/interact.sml
+++ b/base/compiler/TopLevel/interact/interact.sml
@@ -91,6 +91,22 @@ functor Interact(EvalLoop : EVALLOOP) : INTERACT =
 
     fun useStream stream = EvalLoop.evalStream ("<instream>", stream)
 
+    (* Added by DAYA*)
+    
+    fun useScriptFile (fname, stream) = ( 
+      
+      Mutecompiler.silenceCompiler () ;
+      EvalLoop.evalStream ("<instream>", (TextIO.openString "Backend.Mutecompiler.mcdummyfn ();") ) ;
+      Mutecompiler.unsilenceCompiler () ;
+
+      (EvalLoop.evalStream (fname, stream))
+        handle exn => ( 
+          Mutecompiler.printStashedCompilerOutput ();
+          Mutecompiler.unsilenceCompiler ();
+          EvalLoop.uncaughtExnMessage exn
+          )  
+      )
+
     fun evalStream (stream, baseEnv) = let
 	  val r = ref Environment.emptyEnv
 	  val base = { set = fn _ => raise Fail "evalStream: #set base",

--- a/base/compiler/TopLevel/interact/mutecompiler.sig
+++ b/base/compiler/TopLevel/interact/mutecompiler.sig
@@ -1,0 +1,27 @@
+(* mutecompiler.sig
+ *
+ * COPYRIGHT (c) 2019 The Fellowship of SML/NJ (http://www.smlnj.org)
+ * All rights reserved.
+ *)
+
+signature MUTECOMPILER =
+  sig
+
+    val printlineLimit : int ref
+    val compilerMuted : bool ref
+    val isNewline : char -> bool
+    val push : 'a list ref -> 'a -> unit
+    val installPrintingLimitSettings : int list -> unit
+    val saveControlPrintOut : unit -> unit
+    val stashCompilerOutput : string -> unit
+    val savePrintingLimits : unit -> unit
+    val lowerPrintingLimitsToMin : unit -> unit
+    val restoreControlPrintOut : unit -> unit
+    val restorePrintingLimits : unit -> unit   
+    val outputFlush : TextIO.outstream -> TextIO.vector -> unit
+    val silenceCompiler : unit -> unit
+    val unsilenceCompiler : unit -> unit
+    val printStashedCompilerOutput : unit -> unit
+    val mcdummyfn : unit -> unit
+
+  end  (* signature MUTECOMPILER *)

--- a/base/compiler/TopLevel/interact/mutecompiler.sml
+++ b/base/compiler/TopLevel/interact/mutecompiler.sml
@@ -1,0 +1,142 @@
+(* mutecompiler.sml
+ *
+ * COPYRIGHT (c) 2017 The Fellowship of SML/NJ (http://www.smlnj.org)
+ * All rights reserved.
+ *)
+
+structure Mutecompiler : MUTECOMPILER =
+  struct
+
+  (* compile and execute the contents of a file. *)
+  local    
+    val printingLimitRefs =
+          let open Control.Print
+          in [
+              printDepth, (* default: 5 , max 10 *)
+              printLength, (* default: 12 , max 16 *)
+              stringDepth, (* default: 70 *)
+              intinfDepth (* default: 70 *)
+              ]
+          end;
+
+    val savedControlPrintOut = ref NONE;
+
+    val savedPrintingLimitSettings = ref NONE;
+        
+    val compilerOutputPreviousFullLines = ref ([] : string list);
+    
+    val compilerOutputCurrentLine = ref ([] : string list);
+
+
+
+  in
+
+    val printlineLimit = ref 5;
+
+    val compilerMuted = ref false;
+
+        (* 121 *)
+    fun isNewline #"\n" = true
+      | isNewline _ = false;
+
+    (* 122 *)
+    fun push stack item = stack := item :: ! stack; 
+
+    (* 221 *)
+    fun installPrintingLimitSettings settings =
+          ListPair.app (op :=) (printingLimitRefs, settings);
+
+    (* 11 *)
+    fun saveControlPrintOut () = 
+            if isSome (! savedControlPrintOut)
+            then ()
+            else savedControlPrintOut := SOME (! Control.Print.out);
+
+    (* 12 *)
+    fun stashCompilerOutput string
+      = case String.fields isNewline string   
+         of nil => raise (Fail "impossible ") (* 121 *)
+          | [chunk] => push compilerOutputCurrentLine chunk (* 122 *)
+          | chunk :: lines
+            => (if chunk <> "" then push compilerOutputCurrentLine chunk else ();
+                push compilerOutputPreviousFullLines
+                     (String.concat (rev (! compilerOutputCurrentLine)));
+                let val (last :: others) = rev lines
+                in app (push compilerOutputPreviousFullLines)
+                       (rev others);
+                   compilerOutputCurrentLine
+                   := (if last <> "" then [last] else [])
+                end);
+        
+    (* 13 *)
+    fun savePrintingLimits () =
+            if isSome (! savedPrintingLimitSettings)
+            then ()
+            else savedPrintingLimitSettings := SOME (map ! printingLimitRefs);
+
+    (* 14 *)
+    fun lowerPrintingLimitsToMin () =
+          List.app (fn r => r := 0) printingLimitRefs;
+
+    (* 21 *)
+    fun restoreControlPrintOut () =
+            case ! savedControlPrintOut of
+                NONE => ()
+              | SOME value => (savedControlPrintOut := NONE;
+                               Control.Print.out := value);
+    (* 22 *)
+    fun restorePrintingLimits () =
+            case ! savedPrintingLimitSettings of
+                NONE => ()
+              | SOME settings => (savedPrintingLimitSettings := NONE;
+                                  installPrintingLimitSettings settings); (* 221*)
+    (* 311 *)
+    fun outputFlush f s = (TextIO.output (f, s); TextIO.flushOut f);
+
+    (* 31 *)
+    val printStdErr = outputFlush TextIO.stdErr;
+
+    (* 1 *)
+    fun silenceCompiler () =
+           (compilerMuted := true;
+            saveControlPrintOut ();  (* 11 *)
+            Control.Print.out := { flush = fn () => (), say = stashCompilerOutput }; (* 12 *)
+            savePrintingLimits (); (* 13 *)
+            lowerPrintingLimitsToMin ()); (* 14 *)
+
+    (* 2 *)    
+    fun unsilenceCompiler () = (compilerMuted := false;
+                              restoreControlPrintOut (); (* 21 *)
+                              restorePrintingLimits ()); (* 22 *)
+                                
+    (* dummy function to silence the autoloading messages *)
+    fun mcdummyfn () = ( );
+    
+    (* 3 *)
+    fun printStashedCompilerOutput ()
+      = let val completeLines = length (! compilerOutputPreviousFullLines)
+            val partialLine = 0 < length (! compilerOutputCurrentLine)
+            val partialLines = if partialLine then 1 else 0
+            val stashedOutput = 0 < completeLines orelse partialLine
+        in if stashedOutput andalso (!compilerMuted)
+          then (printStdErr ("___________________________________________________________________\n");
+                 let val linesShown
+                       = ((if partialLine then [String.concat (rev (! compilerOutputCurrentLine))] else [])
+                          @ List.take (! compilerOutputPreviousFullLines,
+                                       Int.min (completeLines,
+                                                !printlineLimit - partialLines)))
+                     val numLinesShown = length linesShown
+                     val last = completeLines + partialLines
+                     val first = last - numLinesShown + 1
+                 in printStdErr (String.concat ["The last " ^ Int.toString (!printlineLimit) ^ " lines " ^ Int.toString first ^ " through " ^ Int.toString last ^ " of suppressed compiler messages are:\n"]);
+                    foldr (fn (line, ()) => printStdErr (line ^ "\n"))
+                          ()
+                          linesShown
+                 end;
+                 printStdErr ("_____________End of suppressed compiler messages.__________________\n")
+                 )
+            else ()
+        end;
+  end
+
+  end (* structure Mutecompiler *)

--- a/base/compiler/core.cm
+++ b/base/compiler/core.cm
@@ -166,7 +166,6 @@ TopLevel/interact/interact.sml
 TopLevel/interact/mutecompiler.sig
 TopLevel/interact/mutecompiler.sml
 
-
 TopLevel/backend/backend.sig
 TopLevel/backend/backend-fn.sml
 
@@ -370,4 +369,3 @@ $/pickle-lib.cm
 $smlnj/init/init.cmi : cm          (* to gain access at CoreIntInf *)
 
 $smlnj/internal/smlnj-version.cm
-

--- a/base/compiler/core.cm
+++ b/base/compiler/core.cm
@@ -163,6 +163,9 @@ TopLevel/interact/evalloop.sig
 TopLevel/interact/evalloop.sml
 TopLevel/interact/interact.sig
 TopLevel/interact/interact.sml
+TopLevel/interact/mutecompiler.sig
+TopLevel/interact/mutecompiler.sml
+
 
 TopLevel/backend/backend.sig
 TopLevel/backend/backend-fn.sml
@@ -367,3 +370,4 @@ $/pickle-lib.cm
 $smlnj/init/init.cmi : cm          (* to gain access at CoreIntInf *)
 
 $smlnj/internal/smlnj-version.cm
+

--- a/base/system/smlnj/internal/boot-env-fn.sml
+++ b/base/system/smlnj/internal/boot-env-fn.sml
@@ -15,6 +15,7 @@ functor BootEnvF (datatype envrequest = AUTOLOAD | BARE
 		  val architecture: string
 		  val cminit : string * DynamicEnv.env * envrequest
 			       * (TextIO.instream -> unit)(* useStream *)
+				   * (string * TextIO.instream -> unit) (* useScriptFile *)
 			       * (string -> unit) (* useFile *)
 			       * ((string -> unit) -> (string -> unit))
 			                          (* errorwrap *)
@@ -70,7 +71,8 @@ functor BootEnvF (datatype envrequest = AUTOLOAD | BARE
 	      U.pStruct := U.NILrde;
 	      cminit (bootdir, de, er,
 		      Backend.Interact.useStream,
-		      errorwrap false useFile,
+			  Backend.Interact.useScriptFile,
+			  errorwrap false useFile,
 		      errorwrap true,
 		      Backend.Interact.installCompManagers)
 	    end

--- a/base/system/smlnj/internal/boot-env-fn.sml
+++ b/base/system/smlnj/internal/boot-env-fn.sml
@@ -15,7 +15,7 @@ functor BootEnvF (datatype envrequest = AUTOLOAD | BARE
 		  val architecture: string
 		  val cminit : string * DynamicEnv.env * envrequest
 			       * (TextIO.instream -> unit)(* useStream *)
-				   * (string * TextIO.instream -> unit) (* useScriptFile *)
+			       * (string * TextIO.instream -> unit) (* useScriptFile *)
 			       * (string -> unit) (* useFile *)
 			       * ((string -> unit) -> (string -> unit))
 			                          (* errorwrap *)
@@ -71,8 +71,8 @@ functor BootEnvF (datatype envrequest = AUTOLOAD | BARE
 	      U.pStruct := U.NILrde;
 	      cminit (bootdir, de, er,
 		      Backend.Interact.useStream,
-			  Backend.Interact.useScriptFile,
-			  errorwrap false useFile,
+		      Backend.Interact.useScriptFile,
+		      errorwrap false useFile,
 		      errorwrap true,
 		      Backend.Interact.installCompManagers)
 	    end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Script execution made simple with SML/NJ - This change is to give the programmers and developers the capability of running a SML program as a script. Also the capability to mute and unmute compiler messages. Programmers and developers can write a SML program and run the program like a script over the command prompt.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

