### PR TITLE
Fix bootstrapping bugs on arm-darwin

### DIFF
--- a/base/runtime/kernel/boot.c
+++ b/base/runtime/kernel/boot.c
@@ -216,6 +216,15 @@ PVT FILE *OpenBinFile (const char *fname, bool_t isBinary)
  */
 PVT void ReadBinFile (FILE *file, void *buf, int nbytes, const char *fname)
 {
+    /* When Apple Silicon platforms execute x64 code through Rosetta,
+     * fread (and POSIX read) sometimes reads incorrect bytes from a
+     * file and corrupts the permission of the memory region in which
+     * the buffer resides. The following code is a workaround that uses
+     * fgetc, which seems to behaves correctly.
+     *
+     * TODO: Remove this special case when Apple has fixed the issue or
+     * when we have a native Arm build.
+     */
 
 #if (defined(OPSYS_DARWIN))
     char *bufc = buf;

--- a/base/runtime/kernel/boot.c
+++ b/base/runtime/kernel/boot.c
@@ -216,9 +216,8 @@ PVT FILE *OpenBinFile (const char *fname, bool_t isBinary)
  */
 PVT void ReadBinFile (FILE *file, void *buf, int nbytes, const char *fname)
 {
-    /* if (fread(buf, nbytes, 1, file) == -1) */
-	/* Die ("cannot read file \"%s\"", fname); */
 
+#if (defined(OPSYS_DARWIN))
     char *bufc = buf;
     for (size_t i = 0; i < (size_t) nbytes; i++) {
         int byte = fgetc(file);
@@ -228,6 +227,10 @@ PVT void ReadBinFile (FILE *file, void *buf, int nbytes, const char *fname)
 
         bufc[i] = byte;
     }
+#else
+    if (fread(buf, nbytes, 1, file) == -1)
+        Die ("cannot read file \"%s\"", fname);
+#endif
 
 } /* end of ReadBinFile */
 

--- a/base/runtime/kernel/boot.c
+++ b/base/runtime/kernel/boot.c
@@ -216,8 +216,18 @@ PVT FILE *OpenBinFile (const char *fname, bool_t isBinary)
  */
 PVT void ReadBinFile (FILE *file, void *buf, int nbytes, const char *fname)
 {
-    if (fread(buf, nbytes, 1, file) == -1)
-	Die ("cannot read file \"%s\"", fname);
+    /* if (fread(buf, nbytes, 1, file) == -1) */
+	/* Die ("cannot read file \"%s\"", fname); */
+
+    char *bufc = buf;
+    for (size_t i = 0; i < (size_t) nbytes; i++) {
+        int byte = fgetc(file);
+        if (byte == EOF) {
+            Die("cannot read file \"%s\"", fname);
+        }
+
+        bufc[i] = byte;
+    }
 
 } /* end of ReadBinFile */
 

--- a/base/runtime/objs/mk.amd64-darwin
+++ b/base/runtime/objs/mk.amd64-darwin
@@ -11,7 +11,7 @@ SHELL =		/bin/sh
 
 MAKE =		make
 AS =		/usr/bin/as -arch x86_64
-CC =		/usr/bin/clang -m64 -std=c99
+CC =		/usr/bin/clang -m64 -std=c99 -target x86_64-apple-darwin
 CFLAGS =	-g -O2 -D_DARWIN_C_SOURCE
 CPP =           /usr/bin/clang -x assembler-with-cpp -E -P -std=c99
 AR =		/usr/bin/ar

--- a/base/runtime/objs/mk.amd64-darwin
+++ b/base/runtime/objs/mk.amd64-darwin
@@ -10,6 +10,8 @@ SDK =		-mmacosx-version-min=10.10
 SHELL =		/bin/sh
 
 MAKE =		make
+# Explicitly stating the target to let Arm machines use x64 system headers
+# and assembler.
 AS =		/usr/bin/as -arch x86_64
 CC =		/usr/bin/clang -m64 -std=c99 -target x86_64-apple-darwin
 CFLAGS =	-g -O2 -D_DARWIN_C_SOURCE


### PR DESCRIPTION
The system failed to bootstrap on MacBooks with Apple Silicon due to the following two problems:

1. The assembler reads X64 assembly source as Arm assembly source;
2. The runtime system loads incorrect binary code from downloaded files because `fread` misbehaves on this platform.

### Problem 1
The `arm-darwin` system is built by cross-compiling the source in `x64-darwin` and is then run through Rosetta; thus, the build system for `arm` simply uses `x64`'s Makefiles. This works when compiling the source on `x64-darwin` for `arm-darwin`. When compiling the source on `arm-darwin` for itself, however, the compiler uses Arm's `struct` definitions and assembler, causing compiler errors. This problem is fixed by explicitly stating the target in `x64-darwin`'s Makefile.
For true `x64-darwin` systems, this should be a no-op, but for `arm-darwin`, this would use the intended headers and assembler.

### Problem 2
`fread` with Rosetta on my machine sometimes reads wrong bytes from a file. I discovered this fact by comparing a hex-dump of the memory buffer and the original file at the same offset. As a result, the bootstrapper executes made-up instructions, causing segfaults. This problem is fixed by replacing `fread` with repeated `fgetc` in `ReadBinFile` from `base/runtime/kernel/boot.c`, and this problem seems to go away. This change should be a temporary fix before Apple fixes the issues with `fread`. 

## Related Issue
Running the `install` script causes errors on `arm-darwin`. I would like to know if other `arm` machines have the same issue with `fread` as it is unbelievable that this bug exists.

## How Has This Been Tested?
With these two changes, the `install` script runs to completion without errors, and the system seems to work.

