### PR TITLE
`HashSetFn.isSubset` function accesses out of bound element

### DIFF
--- a/smlnj-lib/Util/hash-set-fn.sml
+++ b/smlnj-lib/Util/hash-set-fn.sml
@@ -190,7 +190,7 @@ functor HashSetFn (Key : HASH_KEY) : MONO_HASH_SET =
             then let
               val arr1 = !tbl1 and arr2 = !tbl2
               val sz1 = Array.length arr1 and sz2 = Array.length arr2
-              fun lp i = if (i <= sz1)
+              fun lp i = if (i < sz1)
                     then let
                     (* iterate over the items in bucket i *)
                       fun look1 NIL = lp(i+1)


### PR DESCRIPTION

```sml
structure IntHashSet = HashSetFn(IntHashTable.Key)

val set1 = IntHashSet.mkFromList [1]
val set2 = IntHashSet.mkFromList [1]

val chk = IntHashSet.isSubset (set1, set2)
```
Running the above code snippet results in the following exception:
```
Standard ML of New Jersey (64-bit) v110.99.5 [built: Thu Mar 14 17:56:03 2024]
[opening subset.sml]
[autoloading]
[library $SMLNJ-LIB/Util/smlnj-lib.cm is stable]
[autoloading done]

uncaught exception Subscript [subscript out of bounds]
  raised at: ../../smlnj-lib/Util/hash-set-fn.sml:208.32-208.41
```

## Description
The highest index in an array of length `n` is `n - 1`; however, the `isSubset` function uses `i <= sz` to test the end of the array.