### PR TITLE
Add macOS 15 (Sequoia) to _arch-n-opsys script

### DIFF
--- a/config/_arch-n-opsys
+++ b/config/_arch-n-opsys
@@ -92,6 +92,7 @@ case `uname -s` in
 	  21*) REQUIRE_64BIT=yes ;; # macOS 12 Monterey
 	  22*) REQUIRE_64BIT=yes ;; # macOS 13 Ventura
 	  23*) REQUIRE_64BIT=yes ;; # macOS 14 Sonoma
+	  24*) REQUIRE_64BIT=yes ;; # macOS 15 Sequoia
           *) exit 1 ;;
         esac
         if [ x"$REQUIRE_64BIT" = xyes -a $SIZE = 32 ] ; then


### PR DESCRIPTION
On macOS 15 Sequoia Developer Beta, the output of `uname -r` is `24.0.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
On macOS 15 Sequoia Developer Beta, the output of `uname -r` is `24.0.0`. Add an extra case statement to support this version.

## Related Issue
Fixes #315.

## Motivation and Context
Title and #315 are self-descriptive.

## How Has This Been Tested?
I modified `/usr/local/smlnj/bin/.arch-n-opsys` in my local install with this change on a macOS 15 machine.

