### PR TITLE
Remove useless branches in `HashSetFn` insert

### DIFF
--- a/smlnj-lib/Util/hash-set-fn.sml
+++ b/smlnj-lib/Util/hash-set-fn.sml
@@ -87,18 +87,12 @@ functor HashSetFn (Key : HASH_KEY) : MONO_HASH_SET =
 		Array.update(arr, indx, B(h, item, Array.sub(arr, indx)));
 		nItems := !nItems + 1;
 		growTableIfNeeded (table, !nItems);
-		NIL)
+		())
 	    | look (B(h', item', r)) = if ((h = h') andalso same(item, item'))
-		then NIL (* item already present *)
-		else (case (look r)
-		   of NIL => NIL
-		    | rest => B(h', item', rest)
-		  (* end case *))
+		then () (* item already present *)
+		else look r
 	  in
-	    case (look (Array.sub (arr, indx)))
-	     of NIL => ()
-	      | b => Array.update(arr, indx, b)
-	    (* end case *)
+	    look (Array.sub (arr, indx))
 	  end
 
   (* Add an item to a set *)


### PR DESCRIPTION
`HashSetFn` uses a helper function `addWithHash` to handle insertion. `addWithHash` has conditional branches in which only one branch could ever be taken.

## Description
Inserting an element into a hash set is currently handled by the following helper function `addWithHash`.

```sml
fun addWithHash (tbl as SET{table, nItems}, h, item) = let
      val arr = !table
      val sz = Array.length arr
      val indx = index (h, sz)
      fun look NIL = (
            Array.update(arr, indx, B(h, item, Array.sub(arr, indx)));
            nItems := !nItems + 1;
            growTableIfNeeded (table, !nItems);
            NIL)
        | look (B(h', item', r)) = if ((h = h') andalso same(item, item'))
            then NIL (* item already present *)
            else (case (look r)
               of NIL => NIL
                | rest => B(h', item', rest)
              (* end case *))
      in
        case (look (Array.sub (arr, indx)))
         of NIL => ()
          | b => Array.update(arr, indx, b)
        (* end case *)
      end
```
`look` has three cases, and in all three cases, it returns `NIL`:
1. If the element is not found by the end of the chain, the function prepends element to the chain and returns `NIL`.
2. If the element is found in the chain, the function does nothing, keeping the original item, and returns `NIL`.
3. Otherwise, the function calls itself with the rest of the chain, and by induction, it always returns `NIL`.

The return value would be something other than `NIL` if in the second case the function replaces the original item with the new item --- as is the case in a hash _table_ --- and returns `B (h, item, r)`.

The proposed fix is to change the return type of `look` to `unit` and to remove all case analyses for the return value of `look`.

## Motivation and Context
This issue was discovered when profiling the performance of a program that uses hash sets heavily.

## How Has This Been Tested?
Initially, an exception was raised if the function returns any other value. Running the aforementioned program did not trigger the exception. The insertion speed of 3 million elements was measured and there is an observable performance improvement over large number of insertions.
