### PR TITLE
`Control.Elab.ovlddisable`: Disable integer overloading

### DIFF
--- a/base/compiler/Elaborator/control/elabcontrol.sig
+++ b/base/compiler/Elaborator/control/elabcontrol.sig
@@ -26,6 +26,7 @@ signature ELAB_CONTROL =
     val unidebugging : bool ref
 	(* Unify *)
     val ovlddebugging : bool ref
+    val ovlddisable : bool ref
 	(* Overload *)
     val instantiateSigs : bool ref
 	(* ElabMod, Control_MC *)

--- a/base/compiler/Elaborator/control/elabcontrol.sml
+++ b/base/compiler/Elaborator/control/elabcontrol.sml
@@ -72,6 +72,8 @@ structure ElabControl : ELAB_CONTROL =
 
     val printAbsyn = ref false
 
+    val ovlddisable = onew ("ovld-disable", "disable overloading", false)
+
   (***** Controls for warning messages *****)
 
 (* NOTE: we currently disable this check because of false positives for


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change adds the controls flag `ovlddisable` that prevents the toplevel functions `~ + - * div mod < <= > >= abs` as well as integer and word literals from participating in overload resolution.
These functions will take on their default types, which is `int` for the functions and integer literals, and `word` for word literals.

## Description
<!--- Describe your changes in detail -->
This adds the flag to the Elaborator controls file.
It also adds a dummy "Overload.new" function that resolves variables and literals immediately, instead of waiting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When teaching Standard ML, one thing to stress is how everything is properly typed.
Showing this off in SML/NJ leaves one bewildered:

    - [1, true];
    stdIn:1.2-1.11 Error: operator and operand do not agree [overload - bad instantiation]
      operator domain: 'Z[INT] * 'Z[INT] list
      operand:         'Z[INT] * bool list
      in expression:
        1 :: true :: nil

This issue has even gotten worse from older releases, since in 110.79.0 the overloaded types were displayed as `[int ty]` instead of the scary `'Z[INT]`.

With this flag, one gets a much nicer error message:

    - Control.Elab.ovlddisable := true;
    - [1, true];
    stdIn:4.1-4.10 Error: operator and operand do not agree [tycon mismatch]
      operator domain: int * int list
      operand:         int * bool list
      in expression:
        1 :: true :: nil

This commit is not aimed at the development version of SML/NJ for good reason: this is a hack.
Really the compiler should either instantiate overloaded types before showing them to users such as MLton does.
But since SML/NJ is currently being used by students that have no use for language features such as overloading, this should be able to be hidden from view.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has not been extensively tested.

