### PR TITLE
Miscellaneous additions

### DIFF
--- a/base/system/Basis/Implementation/Unsafe/unsafe.sig
+++ b/base/system/Basis/Implementation/Unsafe/unsafe.sig
@@ -92,4 +92,7 @@ signature UNSAFE =
 
     val sigHandler : ((int * int * unit Cont.cont) -> unit Cont.cont) ref
 
+    (* Check for pointer equality. Can return false even when equal. *)
+    val ptrEq : 'a * 'a -> bool
+
   end;

--- a/base/system/Basis/Implementation/Unsafe/unsafe.sml
+++ b/base/system/Basis/Implementation/Unsafe/unsafe.sml
@@ -130,6 +130,8 @@ structure Unsafe :> UNSAFE =
 
     val cast = InlineT.cast
 
+    fun ptrEq (x : 'a, y : 'a) = (cast x : word) = (cast y : word)
+
     (* actual representation of pStruct *)
     datatype runDynEnv
       = NILrde

--- a/base/system/Basis/Implementation/time.sig
+++ b/base/system/Basis/Implementation/time.sig
@@ -12,6 +12,7 @@ signature TIME =
     exception Time
 
     val zeroTime : time
+    val tick     : time
 
     val fromReal : real -> time
     val toReal   : time -> real

--- a/base/system/Basis/Implementation/time.sml
+++ b/base/system/Basis/Implementation/time.sml
@@ -31,6 +31,7 @@ structure TimeImp : sig
     val op quot = LInt.quot
 
     val zeroTime = PB.TIME { usec = 0 }
+    val tick = PB.TIME { usec = 1 }
 
     val fractionsPerSecond : LargeInt.int = 1000000
     fun toFractions (PB.TIME { usec }) = usec

--- a/base/system/Basis/Implementation/universal.sig
+++ b/base/system/Basis/Implementation/universal.sig
@@ -66,4 +66,9 @@ signature UNIVERSAL =
    *)
     val tagProject : 'a tag -> universal -> 'a
 
+  (* `tagTryProject tag un` returns `SOME x` if the universal value `univ` was
+   * formed by the expression `tagInject tag x` and returns `NONE` otherwise.
+   *)
+    val tagTryProject : 'a tag -> universal -> 'a option
+
   end

--- a/base/system/Basis/Implementation/universal.sml
+++ b/base/system/Basis/Implementation/universal.sml
@@ -57,5 +57,6 @@ structure Universal :> UNIVERSAL =
 	   of SOME x => x
 	    | NONE => raise Match
 	  (* end case *))
+    fun tagTryProject (tag : 'a tag) univ = #prj tag univ
 
   end


### PR DESCRIPTION
This PR adds some additional functions to different structures.

## Description

### Time.tick

This is the smallest time value. It is useful to be able to know what the smallest time unit is in code, and this addition was recommended in SMLFamily/BasisLibrary#35.

### Universal.tagTryProject

It is a common usage pattern to do the following:

```sml
val myTag : t Universal.tag = ...
fun myFunc (u : Universal.universal) =
  if Universal.tagIs myTag u
    then doStuff (Universal.tagProject myTag u)
    else doOtherStuff ()
```

Because `universal` is implemented using an optional, this code performs additional checks.
It also encourages a bad pattern (check + unwrap) instead of pattern matching.
Now one can write:

```sml
val myTag : t Universal.tag = ...
fun myFunc (u : Universal.universal) =
  case Universal.tagTryProject myTag u
    of SOME x => doStuff x
     | NONE => doOtherStuff ()
```

### Unsafe.ptrEq

This definition was referenced in #327, and it makes sense to add it to the `Unsafe` module to bless this as a valid implementation.

## How Has This Been Tested?

`Time.tick` and `Universal.tagTryProject` are trivially tested, but these are trivial additions.
`Unsafe.ptrEq` has not been extensively tested.

