### PR TITLE
`UTF8` updates

### DIFF
--- a/base/compiler/Parse/lex/sml.lex
+++ b/base/compiler/Parse/lex/sml.lex
@@ -267,7 +267,7 @@ bad_escape="\\"[\000-\008\011\012\014-\031 !#$%&'()*+,\-./:;<=>?@A-Z\[\]_`c-eg-m
                     val x = Word.toIntX (valOf (Word.fromString (String.substring(yytext, 2, 4))))
                     in
 		      if x>255
-			then err (yypos,yypos+4) COMPLAIN (concat[
+			then err (yypos,yypos+6) COMPLAIN (concat[
                             "illegal string escape '", yytext, "' is too large"
                           ]) nullErrorBody
 			else addChar(charlist, Char.chr x);

--- a/smlnj-lib/Util/utf8-sig.sml
+++ b/smlnj-lib/Util/utf8-sig.sml
@@ -11,7 +11,19 @@ signature UTF8 =
 
     type wchar = word
 
-    val maxCodePoint : wchar	(* = 0wx0010FFFF *)
+    val maxCodePoint : wchar	       (* = 0wx0010FFFF *)
+    val replacementCharacter : wchar (* = 0wxFFFD *)
+
+    datatype decode_strategy =
+      (* raises `Incomplete` when the end of input is encountered in the
+       * middle of an otherwise acceptable multi-byte encoding,
+       * and raises `Invalid` when an invalid byte is encountered.
+       * This is the default decoding option. *)
+        DECODE_STRICT
+      (* replaces invalid input with REPLACEMENT CHARACTER (U+FFFD)
+       * using the W3C standard substitution of maximal subparts algorithm
+       * https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G66453 *)
+      | DECODE_REPLACE
 
     (* raised by some operations when applied to incomplete strings. *)
     exception Incomplete
@@ -29,6 +41,11 @@ signature UTF8 =
      * is encountered.
      *)
     val getu : (char, 'strm) StringCvt.reader -> (wchar, 'strm) StringCvt.reader
+
+    (* convert a character reader to a wide-character reader; the reader
+     * uses the given decoding strategy to handle invalid input.
+     *)
+    val getuWith : decode_strategy -> (char, 'strm) StringCvt.reader -> (wchar, 'strm) StringCvt.reader
 
     (* return the UTF8 encoding of a wide character; raises Invalid if the
      * wide character is larger than the maxCodePoint, but does not do any

--- a/smlnj-lib/Util/utf8.sml
+++ b/smlnj-lib/Util/utf8.sml
@@ -149,10 +149,10 @@ structure UTF8 :> UTF8 =
     fun toString wc =
 	  if isAscii wc
 	    then Char.toCString(toAscii wc)
-	  else if (wc <= max2Byte)
+	  else if (wc <= 0wxFFFF)
 	    then "\\u" ^ (StringCvt.padLeft #"0" 4 (W.toString wc))
 	  (* NOTE: the following is not really SML syntax *)
-	    else "\\u" ^ (StringCvt.padLeft #"0" 8 (W.toString wc))
+	    else "\\U" ^ (StringCvt.padLeft #"0" 8 (W.toString wc))
 
   (* return a list of characters that is the UTF8 encoding of a wide character *)
     fun encode' (wc, chrs) = if (wc <= 0wx7f)

--- a/smlnj-lib/Util/utf8.sml
+++ b/smlnj-lib/Util/utf8.sml
@@ -25,6 +25,7 @@ structure UTF8 :> UTF8 =
     fun w2c w = Char.chr(W.toInt w)
 
     val maxCodePoint : wchar = 0wx0010FFFF
+    val replacementCharacter : wchar = 0wxFFFD
 
   (* maximum values for the first byte for each encoding length *)
     val max1Byte : W.word = 0wx7f (* 0xxx xxxx *)
@@ -40,6 +41,9 @@ structure UTF8 :> UTF8 =
   (* bit mask for continuation bytes *)
     val maskContByte : W.word = 0wx3f
 
+    datatype decode_strategy =
+        DECODE_STRICT
+      | DECODE_REPLACE
 
     exception Incomplete
     exception Invalid
@@ -48,70 +52,57 @@ structure UTF8 :> UTF8 =
      * See https://unicode.org/mail-arch/unicode-ml/y2003-m02/att-0467/01-The_Algorithm_to_Valide_an_UTF-8_String
      * for a description of the state machine.
      *)
-    fun getu getc = let
-          fun getByte inS = (case getc inS
-                 of SOME(c, inS') => (Word.fromInt(ord c), inS')
-                  | NONE => raise Incomplete
+    fun getuWith strategy getc = let
+          fun getByte (inS, k) = (case getc inS
+                 of SOME(c, inS') => k (Word.fromInt(ord c), inS')
+                  | NONE => (case strategy of
+                      DECODE_STRICT => raise Incomplete
+                    | DECODE_REPLACE => SOME (replacementCharacter, inS)
+                    (* end case *))
                 (* end case *))
           fun inRange (minB : word, b, maxB) = ((b - minB) <= maxB - minB)
           (* add the bits of a continuation byte to the accumulator *)
           fun addContBits (accum, b) = W.orb(W.<<(accum, 0w6), W.andb(0wx3f, b))
+          (* handles an invalid byte in the input stream *)
+          val invalid = (case strategy of
+                DECODE_STRICT => (fn _ => raise Invalid)
+              | DECODE_REPLACE => (fn inS => SOME (replacementCharacter, inS))
+            (* end case *))
           (* handles last byte for all multi-byte sequences *)
-          fun stateA (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          fun stateA (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx80, b, 0wxbf)
-                    then SOME(addContBits(accum, b), inS)
-                    else raise Invalid
-                end
+                    then SOME(addContBits(accum, b), inS')
+                    else invalid inS)
           (* handles second/third byte for three/four-byte sequences *)
-          and stateB (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateB (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx80, b, 0wxbf)
-                    then stateA (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateA (inS', addContBits(accum, b))
+                    else invalid inS)
           (* byte0 = 0b1110_0000 (3-byte sequence) *)
-          and stateC (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateC (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wxa0, b, 0wxbf)
-                    then stateA (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateA (inS', addContBits(accum, b))
+                    else invalid inS)
           (* byte0 = 0b1110_1101 (3-byte sequence) *)
-          and stateD (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateD (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx80, b, 0wx9f)
-                    then stateA (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateA (inS', addContBits(accum, b))
+                    else invalid inS)
           (* byte0 = 0b1111_0001 .. 0b1111_0011 (4-byte sequence) *)
-          and stateE (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateE (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx80, b, 0wxbf)
-                    then stateB (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateB (inS', addContBits(accum, b))
+                    else invalid inS)
           (* byte0 = 0b1111_0000 (4-byte sequence) *)
-          and stateF (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateF (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx90, b, 0wxbf)
-                    then stateB (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateB (inS', addContBits(accum, b))
+                    else invalid inS)
           (* byte0 = 0b1111_1000 (4-byte sequence) *)
-          and stateG (inS, accum) = let
-                val (b, inS) = getByte inS
-                in
+          and stateG (inS, accum) = getByte (inS, fn (b, inS') =>
                   if inRange(0wx80, b, 0wx8f)
-                    then stateB (inS, addContBits(accum, b))
-                    else raise Invalid
-                end
+                    then stateB (inS', addContBits(accum, b))
+                    else invalid inS)
           and start inS = (case getc inS
                  of SOME(c, inS) => let
                       val byte0 = Word.fromInt(ord c)
@@ -133,13 +124,15 @@ structure UTF8 :> UTF8 =
                           then stateF (inS, W.andb(byte0, mask4Byte))
                         else if (byte0 = 0wxf4)
                           then stateG (inS, W.andb(byte0, mask4Byte))
-                          else raise Invalid
+                          else invalid inS
                       end
                   | NONE => NONE
                 (* end case *))
           in
             start
           end
+
+    fun getu getc = getuWith DECODE_STRICT getc
 
     fun isAscii (wc : wchar) = (wc <= max1Byte)
     fun toAscii (wc : wchar) = w2c(W.andb(0wx7f, wc))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

```sml
(* Current *)
> UTF8.toString 0wx3BB;
"\\u000003BB"
> UTF8.toString 0wx1D11E;
"\\u0001D11E"

(* New *)
> UTF8.toString 0wx3BB;
"\\u03BB"
> UTF8.toString 0wx1D11E;
"\\U00001D11E"

(* Current *)
> StringCvt.scanString UTF8.getu "\128";
uncaught exception Invalid
(* New *)
> StringCvt.scanString (UTF8.getuWith UTF8.DECODE_REPLACE) "\128";
SOME 0wxFFFD : UTF8.wchar option
```

## Description

### Fixed cutoff in Unicode character printing

The current implementation uses `max2Byte` (0wxdf), when it should use `0wxFFFF`.
This function handles code points, not their UTF8 encodings.

### Changed 8-character Unicode character printing

The current implementation uses `\uXXXX` for 4 bytes and `\uXXXXXXXX` for 8 bytes.
Although these aren't SML language features, we should follow the decision of C by using capital U for 8 byte escapes to avoid confusion.

### Decoding strategies

`UTF8.getu` is great for walking over valid Unicode strings, but sometimes it's useful to recover encoding errors. The `DECODE_REPLACE` decoding strategy can be provided to `getuWith` to replace these invalid bytes with `REPLACEMENT CHARACTER`.

## Motivation and Context
> Why is this change required? What problem does it solve?

Printing a UTF-8 string using `String.concat (List.map UTF8.toString str)` is confusing, as `"\\u00010000\\u00DF0000"` represents 6 code points (`U+100000`, `U+00DF`, `U+30` x 4).
The change also aligns with other programming languages.

`UTF8.getu` should be enhanced to allow for graceful handling of invalid inputs. The current implementation does not allow for this, as simply skipping a byte after an exception does not mimic best practices for replacement character creation. 

## How Has This Been Tested?

The `DECODE_REPLACE` implementation has been tested on the test cases in the [Unicode recommendations page](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G66453).

