### PR TITLE
Remove reference to storeCnt when unavailable

### DIFF
--- a/base/runtime/gc/init-gc.c
+++ b/base/runtime/gc/init-gc.c
@@ -369,8 +369,6 @@ void GetGCStats (ml_state_t *msp, gc_stats_t *statsOut)
     statsOut->allocCnt = ROUND_COUNT(&heap->numAlloc);
 #ifdef COUNT_STORE_LIST
     statsOut->storeCnt = heap->numStores.cnt;
-#else
-    statsOut->storeCnt = 0;
 #endif
 
     statsOut->allocFirstCnt = ROUND_COUNT(&heap->numAlloc1);


### PR DESCRIPTION
When `COUNT_STORE_LIST` is not defined, the `storeCnt` variable isn't available to be set, so this line causes a compilation error.