### PR TITLE
Added signatures to PackReal64 structures

### DIFF
--- a/base/system/Basis/Implementation/pack-real64-big.sml
+++ b/base/system/Basis/Implementation/pack-real64-big.sml
@@ -4,7 +4,7 @@
  * All rights reserved.
  *)
 
-structure PackReal64Big =
+structure PackReal64Big : PACK_REAL where type real = Real64Imp.real =
   struct
 
     structure BV = InlineT.Word8Vector

--- a/base/system/Basis/Implementation/pack-real64-little.sml
+++ b/base/system/Basis/Implementation/pack-real64-little.sml
@@ -4,7 +4,7 @@
  * All rights reserved.
  *)
 
-structure PackReal64Little =
+structure PackReal64Little : PACK_REAL where type real = Real64Imp.real =
   struct
 
     structure BV = InlineT.Word8Vector


### PR DESCRIPTION
Currently the `PackReal64Little` and `PackReal64Big` structures expose implementation details, this commit fixes that.

```sml
- open PackReal64Little;
opening PackReal64Little
  structure BV :
    sig
      type vector = ?.word8vector
      val create : int -> vector
      val length : vector -> int
      val sub : vector * int -> ?.word8
      val chkSub : vector * int -> ?.word8
      val update : vector * int * ?.word8 -> unit
      val getData : vector -> 'a
    end
  structure BA :
    sig
      type array = ?.word8array
      val newArray0 : unit -> array
      val length : array -> int
      val sub : array * int -> ?.word8
      val chkSub : array * int -> ?.word8
      val update : array * int * ?.word8 -> unit
      val chkUpdate : array * int * ?.word8 -> unit
      val getData : array -> 'a
    end
  structure W64 :
    sig
      val toLarge : ?.word64 -> ?.word64
      val toLargeX : ?.word64 -> ?.word64
      val fromLarge : ?.word64 -> ?.word64
      val toInt : ?.word64 -> int
      val toIntX : ?.word64 -> int
      val fromInt : int -> ?.word64
      val toLargeInt : ?.word64 -> ?.intinf
      val toLargeIntX : ?.word64 -> ?.intinf
      val fromLargeInt : ?.intinf -> ?.word64
      val + : ?.word64 * ?.word64 -> ?.word64
      val - : ?.word64 * ?.word64 -> ?.word64
      val * : ?.word64 * ?.word64 -> ?.word64
      val div : ?.word64 * ?.word64 -> ?.word64
      val mod : ?.word64 * ?.word64 -> ?.word64
      val ~ : ?.word64 -> ?.word64
      val orb : ?.word64 * ?.word64 -> ?.word64
      val xorb : ?.word64 * ?.word64 -> ?.word64
      val andb : ?.word64 * ?.word64 -> ?.word64
      val chkLshift : ?.word64 * word -> ?.word64
      val chkRshift : ?.word64 * word -> ?.word64
      val chkRshiftl : ?.word64 * word -> ?.word64
      val rshift : ?.word64 * word -> ?.word64
      val rshiftl : ?.word64 * word -> ?.word64
      val lshift : ?.word64 * word -> ?.word64
      val notb : ?.word64 -> ?.word64
      val > : ?.word64 * ?.word64 -> bool
      val >= : ?.word64 * ?.word64 -> bool
      val < : ?.word64 * ?.word64 -> bool
      val <= : ?.word64 * ?.word64 -> bool
      val min : ?.word64 * ?.word64 -> ?.word64
      val max : ?.word64 * ?.word64 -> ?.word64
    end
  val ++ : int * int -> int
  type real = ?.Real64Imp.real
  val fromBits : Word64.word -> PackReal64Little.real
  val toBits : ?.real -> ?.word64
  val createW8Vec : int -> Word8Vector.vector
  val bytesPerElem : int
  val isBigEndian : bool
  val toBytes : ?.real -> Word8Vector.vector
  val fromBytes : Word8Vector.vector -> PackReal64Little.real
  val subVec : Word8Vector.vector * int -> PackReal64Little.real
  val subArr : Word8Array.array * int -> PackReal64Little.real
  val update : Word8Array.array * int * ?.real -> unit
```