### PR TITLE
Fix refactoring typo in int-binary-set.sml

### DIFF
--- a/smlnj-lib/Util/int-binary-set.sml
+++ b/smlnj-lib/Util/int-binary-set.sml
@@ -178,8 +178,8 @@ structure IntBinarySet :> ORD_SET where type Key.ord_key = Int.int =
 
     fun split_gt (E,x) = E
       | split_gt (T{elt=v,left=l,right=r,...},x) =
-          if (x < v) then split_gt(r,x)
-          else if (x > v) then concat3(split_gt(l,x),v,r)
+          if (x < v) then concat3(split_gt(l,x),v,r)
+          else if (x > v) then split_gt(r,x)
           else r
 
     fun min (T{elt=v,left=E,...}) = v


### PR DESCRIPTION
## Description
I found a potential refactoring bug in an older commit. See https://github.com/smlnj/legacy/commit/84cb9fe176f01a9abfdfc4f5ba3030dea977cf13#r162001428 for details.

## Related Issue
https://github.com/MLton/mlton/issues/618

## Motivation and Context
I found it trying to see what might be causing https://github.com/MLton/mlton/issues/618

## How Has This Been Tested?
I did not test it.
