### PR TITLE
Remove `$PATH` overrides from configuration scripts

### DIFF
--- a/base/runtime/config/gen-posix-names.sh
+++ b/base/runtime/config/gen-posix-names.sh
@@ -9,10 +9,6 @@
 # Usage: gen-posix-names.sh <prefix> <outfile>
 #
 
-# redefine PATH so that we get the right versions of the various tools
-#
-PATH=/bin:/usr/bin
-
 # set locale variables so that sort works right
 #
 export LC_CTYPE LC_COLLATE

--- a/config/_arch-n-opsys
+++ b/config/_arch-n-opsys
@@ -11,9 +11,6 @@
 #			   by $HEAP_OPSYS
 #
 
-export PATH
-PATH="/bin:/usr/bin"
-
 # the default size; this is set by the config/install.sh script
 #
 SIZE=@SIZE@


### PR DESCRIPTION
The static `$PATH` settings are a constant source of headaches, because forcing the use of the system utilities makes using different compilers impossible. Because the PATH override doesn't affect settings from environment variables (such as `$CPP`), we can also get build system mismatches.

## Motivation and Context
The project is otherwise unable to build on systems that put their C compiler in a different directory, such as `/usr/local/bin`, `/opt/bin`, or `/nix/store/95k9rsn1zsw1yvir8mj824ldhf90i4qw-gcc-wrapper-14.3.0/bin`.

## How Has This Been Tested?
This change allows the code to compile on my machine.

