### PR TITLE
`OS.FileSys.tmpName` should support `TMPDIR`

### DIFF
--- a/base/runtime/c-libs/posix-os/tmpname.c
+++ b/base/runtime/c-libs/posix-os/tmpname.c
@@ -6,15 +6,12 @@
 
 #include "ml-unixdep.h"
 #include <stdio.h>
+#include <limits.h>
 #include "ml-base.h"
 #include "ml-c.h"
 #include "ml-values.h"
 #include "ml-objects.h"
 #include "cfun-proto-list.h"
-
-#if defined(HAS_MKSTEMP) && defined(P_tmpdir)
-#  define TEMPLATE	P_tmpdir "/SMLNJ-XXXXXX"
-#endif
 
 /* _ml_OS_tmpname:
  */
@@ -23,18 +20,33 @@ ml_val_t _ml_OS_tmpname (ml_state_t *msp, ml_val_t arg)
 #if defined(HAS_MKSTEMP) && defined(P_tmpdir)
 
   /* mkstemp was added to the IEEE Std 1003.1 in 2004, so most systems should support it */
-    char	template[sizeof(TEMPLATE)];
-    int		sts;
+#ifdef PATH_MAX
+    char	template[PATH_MAX];
+#else
+    char	template[256];
+#endif
+    int sts;
+    const char *tmpdir = getenv("TMPDIR");
 
-    strcpy (template, TEMPLATE);
-    sts = mkstemp (template);
-
-    if (sts < 0) {
-	return RAISE_SYSERR(msp, sts);
+    if (tmpdir != NULL) {
+        int r = snprintf(template, sizeof(template),
+                "%s/SMLNJ-XXXXXX", tmpdir);
+        if (r < sizeof(template)) {
+            sts = mkstemp(template);
+            if (sts >= 0) {
+                close(sts);
+                return ML_CString(msp, template);
+            }
+        }
     }
-    else {
-	close (sts);  /* close the file descriptor */
-	return ML_CString (msp, template);
+
+    strcpy(template, P_tmpdir "/SMLNJ-XXXXXX");
+    sts = mkstemp(template);
+    if (sts < 0) {
+        return RAISE_SYSERR(msp, sts);
+    } else {
+        close(sts);
+        return ML_CString(msp, template);
     }
 
 #else /* for old systems */


### PR DESCRIPTION
## Description
On Unix systems, the OS.FileSys.tmpName function now uses `$TMPDIR` instead of /tmp if set. This matches the standard behavior of Unix programs, including other programming languages.

## Related Issue
I needed this patch in order to continuously run tests, as running the 3CPS compiler over-and-over quickly fills up /tmp. I haven't had issues with this so far so it's worth upstreaming.

## Motivation and Context
My /tmp is tmpfs, which is quickly overfilled when SML/NJ programs call tmpName.
The TMPDIR environment variable is normally used to change the temporary directory but is not implemented in SML/NJ.

## How Has This Been Tested?
I've used this patch for the past week.
