### PR TITLE
Issue 378 fix

### DIFF
--- a/base/runtime/c-libs/posix-process/exec.c
+++ b/base/runtime/c-libs/posix-process/exec.c
@@ -17,18 +17,17 @@
 ml_val_t _ml_P_Process_exec (ml_state_t *msp, ml_val_t arg)
 {
     int             sts;
-    ml_val_t	    path = REC_SEL(arg, 0);
+    ml_val_t        path = REC_SEL(arg, 0);
     ml_val_t        arglst = REC_SEL(arg, 1);
     char            **argv;
     ml_val_t        p;
     char            **cp;
+    int             nArgs;
 
-      /* use the heap for temp space for the argv[] vector */
-    cp = (char **)(msp->ml_allocPtr);
-#ifdef SIZES_C64_ML32
-      /* must 8-byte align this */
-    cp = (char **)ROUNDUP((Unsigned64_t)cp, ADDR_SZB);
-#endif
+    for (nArgs = 0, p = arglst; p != LIST_nil; p = LIST_tl(p))
+        nArgs++;
+
+    cp = PTR_MLtoC(char *, ML_AllocRaw(msp, BYTES_TO_WORDS((nArgs + 1) * sizeof(char *))));
     argv = cp;
     for (p = arglst;  p != LIST_nil;  p = LIST_tl(p))
         *cp++ = STR_MLtoC(LIST_hd(p));

--- a/base/runtime/c-libs/posix-process/exece.c
+++ b/base/runtime/c-libs/posix-process/exece.c
@@ -19,17 +19,16 @@ ml_val_t _ml_P_Process_exece (ml_state_t *msp, ml_val_t arg)
     int             sts;
     ml_val_t        path = REC_SEL(arg, 0);
     ml_val_t        arglst = REC_SEL(arg, 1);
-    ml_val_t	    envlst = REC_SEL(arg, 2);
+    ml_val_t        envlst = REC_SEL(arg, 2);
     char            **argv, **envp;
     ml_val_t        p;
     char            **cp;
+    int             nArgs;
 
-      /* use the heap for temp space for the argv[] and envp[] vectors */
-    cp = (char **)(msp->ml_allocPtr);
-#ifdef SIZES_C64_ML32
-      /* must 8-byte align this */
-    cp = (char **)ROUNDUP((Unsigned64_t)cp, ADDR_SZB);
-#endif
+    for (nArgs = 0, p = arglst; p != LIST_nil; p = LIST_tl(p))
+        nArgs++;
+
+    cp = PTR_MLtoC(char *, ML_AllocRaw(msp, BYTES_TO_WORDS((nArgs + 1) * sizeof(char *))));
     argv = cp;
     for (p = arglst;  p != LIST_nil;  p = LIST_tl(p))
         *cp++ = STR_MLtoC(LIST_hd(p));

--- a/base/runtime/c-libs/posix-process/execp.c
+++ b/base/runtime/c-libs/posix-process/execp.c
@@ -17,18 +17,17 @@
 ml_val_t _ml_P_Process_execp (ml_state_t *msp, ml_val_t arg)
 {
     int             sts;
-    ml_val_t	    file = REC_SEL(arg, 0);
+    ml_val_t        file = REC_SEL(arg, 0);
     ml_val_t        arglst = REC_SEL(arg, 1);
     char            **argv;
     ml_val_t        p;
     char            **cp;
+    int             nArgs;
 
-  /* use the heap for temp space for the argv[] vector */
-    cp = (char **)(msp->ml_allocPtr);
-#ifdef SIZES_C64_ML32
-  /* must 8-byte align this */
-    cp = (char **)ROUNDUP((Unsigned64_t)cp, ADDR_SZB);
-#endif
+    for (nArgs = 0, p = arglst; p != LIST_nil; p = LIST_tl(p))
+        nArgs++;
+
+    cp = PTR_MLtoC(char *, ML_AllocRaw(msp, BYTES_TO_WORDS((nArgs + 1) * sizeof(char *))));
     argv = cp;
     for (p = arglst;  p != LIST_nil;  p = LIST_tl(p))
         *cp++ = STR_MLtoC(LIST_hd(p));

--- a/base/runtime/gc/ml-objects.c
+++ b/base/runtime/gc/ml-objects.c
@@ -77,12 +77,25 @@ ml_val_t ML_CString (ml_state_t *msp, const char *v)
  */
 ml_val_t ML_CStringList (ml_state_t *msp, char **strs)
 {
-/** NOTE: we should do something about possible GC!!! **/
-    int         i;
+    int         i, j;
     ml_val_t    p, s;
+    Word_t      nbytes;
 
     for (i = 0;  strs[i] != NIL(char *);  i++)
         continue;
+
+    /* Make sure we have enough space to allocate the list */
+    nbytes = i * (3 * WORD_SZB);
+    for (j = 0;  j < i;  j++) {
+        size_t len = strlen(strs[j]);
+        Word_t nwords = BYTES_TO_WORDS(len + 1);
+        if (len > 0 && nwords <= SMALL_OBJ_SZW) {
+            nbytes += WORD_SZB * (nwords + 1); /* +1 for the descriptor word */
+        }
+    }
+    if (NeedGC (msp, nbytes)) {
+        InvokeGC (msp, 0);
+    }
 
     p = LIST_nil;
     while (i-- > 0) {


### PR DESCRIPTION
Address the `/** NOTE: we should do something about possible GC!!! **/` comment that has been in ./runtime/gc/ml-objects.c since at least 110.42 by performing a GC collection if there isn't enough space to build the list of ML strings.

Note: this isn't a complete fix. Its still theoretically possible for an absolutely massive list to crash the program -- we'll have to figure that out some other way.

Fixed another bug along the way, where the `exec` family of functions were using the allocation pointer to hold the argv + envp lists (which could be okay as the process is about to be replaced) but then immediately calling functions that allocate. Since those variables are caller-controlled, they can overflow the headroom so we need to actually allocate the data normally.

Fixes: #378

## Description
Before allocating a list with ML_CStringList, count the total number of bytes that are about to be allocated, and perform a GC cycle if needed.

## How Has This Been Tested?
Works on my machine
